### PR TITLE
Bugfix release 1.2.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,28 @@ Fast, n-dimensional linear interpolation and extrapolation on sparse grids.
 
 Ndpolator is a combined interpolator/extrapolator that operates on sparse (incompletely populated) $n$-dimensional grids. It estimates scalar or vector function values within and beyond the definition range of the grid while still avoiding the need to impute missing data or sacrifice the benefits of structured grids. Ndpolator is written in C for speed and portability; a python wrapper that uses numpy arrays is provided for convenience.
 
+# Recent changes
+
+## ndpolator 1.2.1
+
+* the computation of distance between the query point and the grid was not done correctly in off-grid vertices; fixed.
+
+* the find_nearest() function now stores an array of nearest points sorted by distance.
+
+## ndpolator 1.2
+
+* distance between the query point and the grid for off-grid query points is now explicitly computed and returned.
+
+* github workflows substantially improved.
+
+## ndpolator 1.1
+
+* memory management improvements.
+
+## ndpolator 1.0
+
+* initial release.
+
 # Installation
 
 Ndpolator sources are hosted on pypi; you can install the latest release by issuing:

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = ndpolator
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.2
+PROJECT_NUMBER         = 1.2.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/ndpolator/__init__.py
+++ b/ndpolator/__init__.py
@@ -1,3 +1,3 @@
 from .ndpolator import *
 
-__version__ = '1.2'
+__version__ = '1.2.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "ndpolator"
-version = "1.2"
+version = "1.2.1"
 description = "ndpolator: fast, n-dimensional linear interpolation and extrapolation on sparse grids"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/ndp_types.c
+++ b/src/ndp_types.c
@@ -379,9 +379,20 @@ ndp_table *ndp_table_new_from_data(ndp_axes *axes, int vdim, double *grid)
             table->vmask[i] = 1;
     }
 
-    /* first cpsum hypercubes cannot be fully defined because they have off-grid vertices: */
+    /* cpsum is the number of hypercube vertices on the lower edge */
     for (int i = 0; i < axes->nbasic; i++)
         cpsum += axes->cplen[i];
+    cpsum /= axes->cplen[axes->nbasic-1];
+
+    if (debug) {
+        printf("axlen=[");
+        for (int i = 0; i < axes->len; i++)
+            printf("%d ", axes->axis[i]->len);
+        printf("\b] cplen=[");
+        for (int i = 0; i < axes->len; i++)
+            printf("%d ", axes->cplen[i]);
+        printf("\b] cpsum=%d nverts=%d\n", cpsum, table->nverts);
+    }
 
     table->hcmask = calloc(table->nverts, sizeof(*(table->hcmask)));
     for (int i = cpsum; i < table->nverts; i++) {
@@ -395,7 +406,7 @@ ndp_table *ndp_table_new_from_data(ndp_axes *axes, int vdim, double *grid)
         for (int k = 0; k < axes->nbasic; k++) {
             ith_corner[k] = (i / (axes->cplen[k] / axes->cplen[axes->nbasic-1])) % axes->axis[k]->len;
             if (debug)
-                printf("i=%d k=%d cplen[k]=%d cplen[nbasic-1]=%d ith_corner[k]=%d\n", i, k, axes->cplen[k], axes->cplen[axes->nbasic-1], i / (axes->cplen[k] / axes->cplen[axes->nbasic-1]));
+                printf("i=%d k=%d normed_cplen[k]=%d ith_corner[k]=%d\n", i, k, axes->cplen[k]/axes->cplen[axes->nbasic-1], i / (axes->cplen[k] / axes->cplen[axes->nbasic-1]));
             /* skip edge elements: */
             if (ith_corner[k] == 0) {
                 nan_encountered = 1;

--- a/src/ndpolator.c
+++ b/src/ndpolator.c
@@ -793,8 +793,7 @@ ndp_query *ndpolate(ndp_query_pts *qpts, ndp_table *table, ndp_extrapolation_met
                     /* shift normed query points to account for the new hypercube: */
                     for (int j = 0; j < table->axes->len; j++)
                         qpts->normed[i * table->axes->len + j] += qpts->indices[i * table->axes->len + j] - coords[j]
-                            // + (qpts->flags[i * table->axes->len + j] == NDP_OUT_OF_BOUNDS && qpts->indices[i * table->axes->len + j] < table->axes->axis[j]->len-1)
-                            + ((NDP_ON_VERTEX & qpts->flags[i * table->axes->len + j]) == NDP_ON_VERTEX && qpts->indices[i * table->axes->len + j] > 0);
+                            + ((NDP_ON_VERTEX & qpts->flags[i * table->axes->len + j]) == NDP_ON_VERTEX && qpts->indices[i * table->axes->len + j] > 0 && qpts->indices[i * table->axes->len + j] < table->axes->axis[j]->len-1);
 
                     if (debug) {
                         printf("  updated query_pt[%d] = [", i);


### PR DESCRIPTION
* optimization in storing non-null nodes was overly aggressive and it resulted in incorrect lists when associated axes were added; fixed.
* the computation of distance between the query point and the grid was not done correctly in off-grid vertices; fixed.
* the find_nearest() function now stores an array of nearest points sorted by distance.