### PR TITLE
Workaround for the failing numpy 2.0 cibuildwheel run on pp39-manylinux-i686

### DIFF
--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -29,7 +29,7 @@ jobs:
             - name: Checkout the sources
               uses: actions/checkout@v4
             - name: Build wheels
-              uses: pypa/cibuildwheel@v2.18.1
+              uses: pypa/cibuildwheel@v2.19.1
             - uses: actions/upload-artifact@v4
               with:
                 name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "numpy < 2.0", "pytest"
+    "numpy==1.26.4", "pytest"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "numpy", "pytest"
+    "numpy < 2.0", "pytest"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,14 +44,14 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "numpy==1.26.4", "pytest"
+    "numpy<2.0.0", "pytest"
 ]
 
 [project.urls]
 repository = "https://github.com/aprsa/ndpolator"
 
 [build-system]
-requires = ["setuptools", "numpy", "wheel"]
+requires = ["setuptools", "numpy<2.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
This workaround caps numpy to <2.0 in the toml build dependency declaration. It is a workaround that should be removed once either numpy or cibuildwheel fix numpy 2.0 wheel builds.