### PR TITLE
update release workflow

### DIFF
--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -2,6 +2,7 @@ name: Upload ndpolator to pypi on release
 
 on:
     workflow_dispatch:
+    pull_request:
     release:
         types: [created]
 
@@ -38,6 +39,7 @@ jobs:
                 path: ./wheelhouse/*.whl
 
     publish-to-pypi:
+        if: github.event_name != 'pull_request'
         needs: [build-sdist, build-wheels]
         name: Publish release to PyPI
         runs-on: ubuntu-latest

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -24,12 +24,14 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ubuntu-22.04, macos-13, macos-14]
+                os: [ubuntu-24.04, macos-13, macos-14]
         steps:
             - name: Checkout the sources
               uses: actions/checkout@v4
             - name: Build wheels
-              uses: pypa/cibuildwheel@v2.19.1
+              uses: pypa/cibuildwheel@v2.21.2
+              env:
+                CIBW_SKIP: pp37-* pp38-* pp39-* pp31*-macosx*
             - uses: actions/upload-artifact@v4
               with:
                 name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}


### PR DESCRIPTION
update runner, cibuildwheel version, and skip failing builds from setuptools bug (can be removed in the future).

The second commit makes it so the workflow will build wheels on each PR to ensure they are ready to publish, but does not push to pip except if manually triggered or from a release.  Note however, that this can take quite a while to run (at least on phoebe where there is a lot to build), so maybe you don't want to include this?